### PR TITLE
Use metadata to test DICOM files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Required packages
 The script is written in Python and uses 2 external packages, [VTK](https://vtk.org) and [SimpleITK](https://simpleitk.readthedocs.io/en/master/).
 
 The dependencies can be simply installed by `pip`:
-> pip install SimpleITK vtk
+> pip install SimpleITK vtk pydicom
 
 Alternatively, vtk can be downloaded and built from the following repository:
 > https://github.com/Kitware/VTK

--- a/README.md
+++ b/README.md
@@ -18,18 +18,14 @@ Required packages
 =================
 The script is written in Python and uses 2 external packages, [VTK](https://vtk.org) and [SimpleITK](https://simpleitk.readthedocs.io/en/master/).
 
-vtk can be downloaded and built from the following repository:
+The dependencies can be simply installed by `pip`:
+> pip install SimpleITK vtk
+
+Alternatively, vtk can be downloaded and built from the following repository:
 > https://github.com/Kitware/VTK
 
-Alternatively, on some Linux distributions it can be installed with the following command:
+Or on some Linux distributions it can be installed with the following command:
 > sudo apt-get install vtk
-
-SimpleITK can be installed via the following command:
-> pip SimpleITK
-
-The options for the script can be seen by running it:
-> python dicom2stl.py --help
-
 
 How it works
 ============
@@ -86,5 +82,8 @@ To extract a specific iso-value from a VTK volume:
 To extract soft tissue from a dicom series in directory and
 apply a 180 degree Y axis rotation:
 > python dicom2stl.py --enable rotation -t soft_tissue -o soft.stl dicom_dir
+
+The options for the script can be seen by running it:
+> python dicom2stl.py --help
 
 You can try out an interactive Jupyter notebook via Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dave3d/dicom2stl/master?filepath=examples%2FIsosurface.ipynb)

--- a/dicom2stl.py
+++ b/dicom2stl.py
@@ -25,6 +25,7 @@ import shutil
 import time
 import zipfile
 import vtk
+import re
 import SimpleITK as sitk
 
 import parseargs
@@ -77,7 +78,7 @@ print("")
 tempDir = args.temp
 if tempDir == "":
     tempDir = tempfile.mkdtemp()
-print("Temp dir: ", tempDir)
+    print("Temp dir: ", tempDir)
 
 tissueType = args.tissue
 if tissueType:
@@ -145,7 +146,7 @@ if zipFlag:
     # Case for a zip file of images
     if args.verbose:
         print("zip")
-    img, modality = dicomutils.loadZipDicom(fname[0], tempDir)
+        img, modality = dicomutils.loadZipDicom(fname[0], tempDir)
 
 
 else:
@@ -163,7 +164,16 @@ else:
             modality = dicomutils.getModality(img)
 
         else:
-            # Case for a series of image files
+            # Case for a series of image files 
+            # For files named like IM1, IM2, .. IM10
+            # They would be ordered by default as IM1, IM10, IM2, ...
+            # sort the fname list in correct serial number order
+            RE_NUMBERS = re.compile(r"\d+")
+            def extract_int(file_path):
+                file_name = os.path.basename(file_path)
+                return int(RE_NUMBERS.findall(file_name)[0])
+            fname = sorted(fname, key=extract_int)
+            
             if args.verbose:
                 if args.verbose > 1:
                     print("Reading images: ", fname)
@@ -332,6 +342,8 @@ gc.collect()
 
 # remove the temp directory
 if args.clean:
-    shutil.rmtree(tempDir)
+    # shutil.rmtree(tempDir)
+    # with context manager the temp dir would be deleted any way
+    pass
 
 print("")

--- a/dicom2stl.py
+++ b/dicom2stl.py
@@ -76,8 +76,9 @@ if args.filters:
 
 print("")
 tempDir = args.temp
-if tempDir == "":
-    tempDir = tempfile.mkdtemp()
+if not tempDir:
+    print("Temp dir: Not specified, a temp dir will be created at current path")
+else:
     print("Temp dir: ", tempDir)
 
 tissueType = args.tissue
@@ -146,6 +147,10 @@ if zipFlag:
     # Case for a zip file of images
     if args.verbose:
         print("zip")
+    if not tempDir:
+        with tempfile.TemporaryDirectory() as defaultTempDir:
+            img, modality = dicomutils.loadZipDicom(fname[0], defaultTempDir)
+    else:
         img, modality = dicomutils.loadZipDicom(fname[0], tempDir)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.18.4
 SimpleITK==1.2.4
 vtk==8.1.2
+pydicom==2.1.2

--- a/utils/dicomutils.py
+++ b/utils/dicomutils.py
@@ -21,13 +21,29 @@ import fnmatch
 import zipfile
 import SimpleITK as sitk
 
+from pydicom.filereader import read_file_meta_info
+from pydicom.errors import InvalidDicomError
+
+
+
+def testDicomFile(file_path):
+    """Test if given file is in DICOM format."""
+    try:
+        read_file_meta_info(file_path)
+        return True
+    except InvalidDicomError:
+        return False
+
 
 def scanDirForDicom(dicomdir):
     matches = []
     dirs = []
     for root, dirnames, filenames in os.walk(dicomdir):
-        for filename in fnmatch.filter(filenames, '*.dcm'):
-            matches.append(os.path.join(root, filename))
+        for filename in filenames:
+            abs_file_path = os.path.join(root, filename)
+            if not testDicomFile(abs_file_path):
+                continue
+            matches.append(abs_file_path)
             if root not in dirs:
                 dirs.append(root)
 


### PR DESCRIPTION
A few patches:
1. use metadata to test DICOM files instead of relaying on file extension, for that sometimes the DICOM files have no extension.
2. use python built-in temporary directory module to place temporary files in system tmp path
3. add edge case handling where files don't have the same amount of digits which causes wrong file order